### PR TITLE
Reset tokens json file when os env token updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,4 +129,4 @@ dmypy.json
 .pyre/
 
 # emo_platform_api tokens
-emo_platform/tokens/emo-platform-api.json
+emo_platform/tokens/*.json


### PR DESCRIPTION
- トークンについて
  - 今までjsonファイル読み込みの優先度を環境変数より高くしていたため、違うBOCCO acountに切り替える際に、環境変数を更新しても切り替えることができない状態になっていた
  - client初期化時に現在の環境変数を保存し、前回のと比較して更新されていた場合は、jsonファイルを初期化するようにした