### PR TITLE
Added conversation APIs

### DIFF
--- a/emo_platform/api_async.py
+++ b/emo_platform/api_async.py
@@ -28,6 +28,7 @@ from emo_platform.response import (
     EmoMessageInfo,
     EmoMotionsInfo,
     EmoMsgsInfo,
+    EmoPostConversation,
     EmoRoomInfo,
     EmoRoomSensorInfo,
     EmoSensorsInfo,
@@ -154,6 +155,9 @@ class AsyncClient:
                 if not _update_tokens:
                     raise
             else:
+                if len(await response.read()) == 0:
+                    return {}
+
                 return await response.json()
 
         await self._update_tokens()
@@ -195,8 +199,20 @@ class AsyncClient:
             )
             return await self._check_http_error(request, _update_tokens=_update_tokens)
 
-    async def _put(self, path: str, data: str = "{}") -> dict:
+    async def _put(
+        self,
+        path: str,
+        data: Union[str, aiohttp.FormData, aiohttp.MultipartWriter] = "{}",
+        content_type: Optional[str] = PostContentType.APPLICATION_JSON,
+        accept: Optional[str] = "*/*",
+    ) -> dict:
+        if content_type is None:
+            if "Content-Type" in self._client._headers:
+                self._client._headers.pop("Content-Type")
+        else:
+            self._client._headers["Content-Type"] = content_type
         async with aiohttp.ClientSession() as session:
+            self._client._headers["accept"] = accept
             request = partial(
                 session.put,
                 self._client._endpoint_url + path,
@@ -1590,6 +1606,60 @@ class BizAdvancedAsyncClient(BizAsyncClient):
         )
         return response.secret
 
+    async def update_conversation_endpoint(
+        self,
+        api_key: str,
+        service_uuid: str,
+        endpoint: str,
+    ):
+        """対話セッションのコールバックURLの設定
+        対話セッションを通して、BOCCO emoからの応答を受信するためのコールバックURLを設定します。
+        管理画面からも、本APIと同等の操作を行うことが可能です。
+
+        Parameters
+        ----------
+        api_key : str
+            法人向けAPIキー
+
+            法人アカウントでログインした時の `ダッシュボード <https://platform-api.bocco.me/dashboard/>`_
+            から確認することができます。
+
+        service_uuid : str
+            編集したいサービスのUUID
+
+        endpoint : str
+            Conversation機能のイベントを受信するEndpoint.
+
+        Returns
+        -------
+        None
+
+        Raises
+        ----------
+        EmoPlatformError
+            関数内部で行っているAPI呼び出しが失敗した場合。
+
+        Note
+        ----
+        呼び出しているAPI
+            https://platform-api.bocco.me/api-docs/#put-/v1/bocco_channel/services/-service_uuid-/conversation_endpoint
+
+        API呼び出し回数
+            1回 + 1回(access tokenが切れていた場合)
+
+        """
+        with self._client._add_apikey2header(api_key):
+            data = aiohttp.MultipartWriter("form-data")
+            part = data.append(endpoint)
+            part.set_content_disposition("form-data", name="endpoint")
+
+            await self._put(
+                "/v1/bocco_channel/services/" + service_uuid + "/conversation_endpoint",
+                data,
+                content_type=PostContentType.MULTIPART_FORMDATA,
+                accept="multipart/form-data",
+            )
+
 
 class AsyncRoom:
     """部屋固有の各種apiを呼び出す非同期版のclient
@@ -2065,6 +2135,7 @@ class AsyncRoom:
         return EmoSettingsInfo(**response)
 
 
+
 class BizAsyncRoom(AsyncRoom):
     """部屋固有の各種apiを呼び出す非同期版のclient(Business版)
 
@@ -2287,3 +2358,114 @@ class BizAdvancedAsyncRoom(BizAsyncRoom):
     async def send_motion(self, motion_id: str) -> EmoMessageInfo:
         with self._base_client._client._add_apikey2header(self.api_key):
             return await super().send_motion(motion_id)
+
+    async def create_conversation(
+        self,
+    ) -> EmoPostConversation:
+        """対話セッションを開始
+
+        Returns
+        -------
+        response : EmoPostConversation
+            対話セッション情報。
+
+        Raises
+        ----------
+        EmoPlatformError
+            関数内部で行っているAPI呼び出しが失敗した場合。
+
+        Note
+        ----
+        呼び出しているAPI
+            https://platform-api.bocco.me/api-docs/#post-/v1/rooms/-room_uuid-/conversations
+
+        API呼び出し回数
+            1回 + 1回(access tokenが切れていた場合)
+
+        """
+        with self._base_client._client._add_apikey2header(self.api_key):
+            response = await self._base_client._post("/v1/rooms/" + self.room_id + "/conversations")
+            return EmoPostConversation(**response)
+
+    async def create_conversation_recording(
+        self,
+        session_id: str,
+        speech_to_text: bool,
+    ) -> EmoPostConversation:
+        """対話セッション内での音声録音要求
+
+        Parameters
+        ----------
+        session_id : str
+            create_conversation で生成された session_id を指定します。
+
+	    speech_to_text: bool
+            trueの場合、Speech-To-Textを実行した結果も併せて通知します
+
+        Returns
+        -------
+        response : EmoPostConversation
+            対話セッション情報。
+
+        Raises
+        ----------
+        EmoPlatformError
+            関数内部で行っているAPI呼び出しが失敗した場合。
+
+        Note
+        ----
+        呼び出しているAPI
+            https://platform-api.bocco.me/api-docs/#post-/v1/rooms/-room_uuid-/conversations/-session_id-/recording
+
+        API呼び出し回数
+            1回 + 1回(access tokenが切れていた場合)
+
+        """
+        with self._base_client._client._add_apikey2header(self.api_key):
+            payload = {"speech_to_text": speech_to_text}
+            response = await self._base_client._post("/v1/rooms/" + self.room_id + "/conversations/" + session_id + "/recording", json.dumps(payload))
+            return EmoPostConversation(**response)
+
+
+    async def create_conversation_text(
+        self,
+        session_id: str,
+        text: str,
+        display: bool,
+    ) -> EmoPostConversation:
+        """対話セッション内でのテキストメッセージ投稿
+
+        Parameters
+        ----------
+        session_id : str
+            create_conversation で生成された session_id を指定します。
+
+        text : str
+            送信するテキスト。(1-250文字)
+
+	    display: bool
+            trueの場合、チャットルームにもメッセージを投稿します
+
+        Returns
+        -------
+        response : EmoPostConversation
+            対話セッション情報。
+
+        Raises
+        ----------
+        EmoPlatformError
+            関数内部で行っているAPI呼び出しが失敗した場合。
+
+        Note
+        ----
+        呼び出しているAPI
+            https://platform-api.bocco.me/api-docs/#post-/v1/rooms/-room_uuid-/conversations/-session_id-/text
+
+        API呼び出し回数
+            1回 + 1回(access tokenが切れていた場合)
+
+        """
+        with self._base_client._client._add_apikey2header(self.api_key):
+            payload = {"text": text, "display": display}
+            response = await self._base_client._post("/v1/rooms/" + self.room_id + "/conversations/" + session_id + "/text", json.dumps(payload))
+            return EmoPostConversation(**response)

--- a/emo_platform/response.py
+++ b/emo_platform/response.py
@@ -793,6 +793,14 @@ class EmoWebhookBody(PrintModel):
     """
 
 
+class EmoPostConversation(PrintModel):
+    """対話セッションのレスポンス"""
+
+    session_id: str
+    """対話セッションID
+    """
+
+
 def parse_webhook_body(body: dict) -> EmoWebhookBody:
     """受信したwebhookリクエストのボディのJSONペイロードのパース
 


### PR DESCRIPTION
https://platform-api.bocco.me/api-docs/#tag--conversation

Added four endpoint implementations below:

- `POST /v1/rooms/{room_uuid}/conversations`
- `POST /v1/rooms/{room_uuid}/conversations/{session_id}/recording`
- `POST /v1/rooms/{room_uuid}/conversations/{session_id}/text`
- `PUT /v1/bocco_channel/services/{service_uuid}/conversation_endpoint`